### PR TITLE
Fix #19: enable gomod updates in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,11 @@
 
 version: 2
 updates:
- - package-ecosystem: "devcontainers"
-   directory: "/"
-   schedule:
-     interval: weekly
+  - package-ecosystem: "devcontainers"
+    directory: "/"
+    schedule:
+      interval: weekly
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: weekly


### PR DESCRIPTION
## Summary
- update Dependabot to monitor Go modules

## Testing
- `go test ./...` *(fails: proxyconnect tcp dial tcp 172.26.0.3:8080: connect: no route to host)*
- `go vet ./...` *(fails: proxyconnect tcp dial tcp 172.26.0.3:8080: connect: no route to host)*
